### PR TITLE
Fix code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/streamlit_app/app/pages/Folder_Chat.py
+++ b/streamlit_app/app/pages/Folder_Chat.py
@@ -71,8 +71,10 @@ st.subheader("Folder Management")
 new_folder_name = st.text_input("Create a new folder")
 if st.button("Create Folder"):
     if new_folder_name:
-        folder_path = os.path.join(BASE_DIR, new_folder_name)
-        if not os.path.exists(folder_path):
+        folder_path = os.path.normpath(os.path.join(BASE_DIR, new_folder_name))
+        if not folder_path.startswith(os.path.abspath(BASE_DIR)):
+            st.error("Invalid folder name. Please try again.")
+        elif not os.path.exists(folder_path):
             os.makedirs(folder_path)
             st.success(f"Folder '{new_folder_name}' created.")
         else:


### PR DESCRIPTION
Fixes [https://github.com/GSA/FedRAMP-OllaLab-Lean/security/code-scanning/7](https://github.com/GSA/FedRAMP-OllaLab-Lean/security/code-scanning/7)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the `BASE_DIR`. This approach will prevent path traversal attacks by ensuring that the user cannot escape the intended directory.

1. Normalize the `folder_path` using `os.path.normpath`.
2. Check that the normalized `folder_path` starts with `BASE_DIR`.
3. If the check fails, raise an exception or show an error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
