### PR TITLE
Fix code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/jupyter_lab/notebooks/AdvancedRAG/rag-experiment-accelerator/env_to_keyvault.py
+++ b/jupyter_lab/notebooks/AdvancedRAG/rag-experiment-accelerator/env_to_keyvault.py
@@ -18,9 +18,8 @@ if __name__ == "__main__":
 
     environment = Environment.from_env_or_keyvault()
     logger.info("Creating secrets in Keyvault from the environment")
-    logger.info("The following secrets will be created:")
-    for secret in environment.fields():
-        logger.info(f"  - {secret[0]}")
+    secrets = environment.fields()
+    logger.info(f"{len(secrets)} secrets will be created in Keyvault.")
 
     environment.to_keyvault()
     logger.info(


### PR DESCRIPTION
Fixes [https://github.com/GSA/FedRAMP-OllaLab-Lean/security/code-scanning/10](https://github.com/GSA/FedRAMP-OllaLab-Lean/security/code-scanning/10)

To fix the problem, we need to avoid logging sensitive information directly. Instead, we can log a generic message indicating the number of secrets being processed without revealing their actual names or values. This approach maintains the functionality of informing the user about the process without exposing sensitive data.

1. Replace the logging of each secret with a generic message.
2. Update the logger to indicate the number of secrets being processed instead of their names.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
