### PR TITLE
Fix code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/jupyter_lab/notebooks/langchain-examples/all-in-one/pages/2_URL_Summary.py
+++ b/jupyter_lab/notebooks/langchain-examples/all-in-one/pages/2_URL_Summary.py
@@ -24,7 +24,9 @@ if st.button("Summarize"):
         try:
             with st.spinner("Please wait..."):
                 # Load URL data
-                if "youtube.com" in url:
+                from urllib.parse import urlparse
+                parsed_url = urlparse(url)
+                if parsed_url.hostname and (parsed_url.hostname == "youtube.com" or parsed_url.hostname.endswith(".youtube.com")):
                     loader = YoutubeLoader.from_youtube_url(url, add_video_info=True)
                 else:
                     loader = UnstructuredURLLoader(urls=[url], ssl_verify=False, headers={"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"})


### PR DESCRIPTION
Fixes [https://github.com/GSA/FedRAMP-OllaLab-Lean/security/code-scanning/8](https://github.com/GSA/FedRAMP-OllaLab-Lean/security/code-scanning/8)

To fix the problem, we need to parse the URL and check the hostname to ensure it matches "youtube.com" or its subdomains correctly. This can be done using the `urlparse` function from the `urllib.parse` module.

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname is exactly "youtube.com" or ends with ".youtube.com".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
